### PR TITLE
[REVIEW]fix getAllTickets

### DIFF
--- a/zendesk/zd_ticket_service.go
+++ b/zendesk/zd_ticket_service.go
@@ -61,9 +61,10 @@ func (c *client) ShowTicket(id int64) (*Ticket, error) {
 }
 
 func (c *client) GetAllTickets() ([]Ticket, error) {
-	out := new(APIPayload)
-	err := c.get("/api/v2/tickets.json", out)
-	return out.Tickets, err
+	tickets, err := c.getAll("/api/v2/tickets.json", nil)
+	fmt.Println("inside getAllTickets")
+	fmt.Println(tickets)
+	return tickets, err
 }
 
 func (c *client) CreateTicket(ticket *Ticket) (*Ticket, error) {

--- a/zendesk/zd_ticket_service.go
+++ b/zendesk/zd_ticket_service.go
@@ -62,8 +62,6 @@ func (c *client) ShowTicket(id int64) (*Ticket, error) {
 
 func (c *client) GetAllTickets() ([]Ticket, error) {
 	tickets, err := c.getAll("/api/v2/tickets.json", nil)
-	fmt.Println("inside getAllTickets")
-	fmt.Println(tickets)
 	return tickets, err
 }
 

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -331,6 +331,7 @@ type APIPayload struct {
 	Users                   []User                   `json:"users,omitempty"`
 	TicketForm              *TicketForm              `json:"ticket_form,omitempty"`
 	TicketForms             []TicketForm             `json:"ticket_forms,omitempty"`
+	NextPage                string                   `json:"next_page,omitempty"`
 }
 
 // APIError represents an error response returnted by the API.

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -235,22 +235,6 @@ func (c *client) getAll(endpoint string, in interface{})([]Ticket, error) {
 
 	defer res.Body.Close()
 
-	// Retry the request if the retry after header is present. This can happen when we are
-	// being rate limited or we failed with a retriable error.
-	// if res.Header.Get("Retry-After") != "" {
-	// 	after, err := strconv.ParseInt(res.Header.Get("Retry-After"), 10, 64)
-	// 	if err != nil || after == 0 {
-	// 		return unmarshall(res, out)
-	// 	}
-
-	// 	time.Sleep(time.Duration(after) * time.Second)
-
-	// 	res, err = c.request(method, endpoint, headers, bytes.NewReader(payload))
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	defer res.Body.Close()
-	// }
 	err = unmarshall(res, dataPerPage)
 
 	prevPage := ""

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -219,17 +219,18 @@ func (c *client) getAll(endpoint string, in interface{})([]Ticket, error) {
 	result := make([]Ticket, 0)
 	payload, err := marshall(in)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
 	headers := map[string]string{}
 	if in != nil {
 		headers["Content-Type"] = "application/json"
 	}
+
 	res, err := c.request("GET", endpoint, headers, bytes.NewReader(payload))
-	copy := new(APIPayload)
+	dataPerPage := new(APIPayload)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
 	defer res.Body.Close()
@@ -250,22 +251,16 @@ func (c *client) getAll(endpoint string, in interface{})([]Ticket, error) {
 	// 	}
 	// 	defer res.Body.Close()
 	// }
-	err = unmarshall(res, copy)
-	fmt.Println("===============================")
-	fmt.Println("NextPage")
+	err = unmarshall(res, dataPerPage)
+
 	prevPage := ""
-	for copy.NextPage != prevPage {
-		fmt.Println(copy.NextPage[38:])
-		result = append(result, copy.Tickets...)
-		prevPage = copy.NextPage
-		res, _ := c.request("GET", copy.NextPage[38:], headers, bytes.NewReader(payload))
-		err = unmarshall(res, copy)
-		fmt.Println(copy.NextPage)
+	for dataPerPage.NextPage != prevPage {
+		result = append(result, dataPerPage.Tickets...)
+		prevPage = dataPerPage.NextPage
+		res, _ := c.request("GET", dataPerPage.NextPage[38:], headers, bytes.NewReader(payload))
+		err = unmarshall(res, dataPerPage)
 	}
-	fmt.Println(len(result))
-	fmt.Println("===============================")
-	fmt.Println("NextPage")
-	fmt.Println(copy.NextPage)
+
 	return result, err
 }
 


### PR DESCRIPTION
This PR fixes the **getAllTickets** function. The existing **getAllTickets** can only pull 100 items from Zendesk, which is the maximum number allowed per page. Due to the pagination of Zendesk, we need to loop through all the pages to get all the data.

<img width="467" alt="Screen Shot 2019-08-13 at 11 28 22 PM" src="https://user-images.githubusercontent.com/50335005/63000360-d0f07e00-be25-11e9-8fca-c8e0330fc2ec.png">


**NOTE**: need to do more research on the api limiter and make the function more generic. It will be fixed in other PRs.