### PR TITLE
[REVIEW]fix getAll function

### DIFF
--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -243,7 +243,7 @@ func (c *client) getAll(endpoint string, in interface{})([]Ticket, error) {
 		prevPage = dataPerPage.NextPage
 		fmt.Println(prevPage)
 		if prevPage == "" {
-			break;
+			break
 		}
 		res, _ := c.request("GET", dataPerPage.NextPage[38:], headers, bytes.NewReader(payload))
 		dataPerPage = new(APIPayload)

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -241,7 +241,12 @@ func (c *client) getAll(endpoint string, in interface{})([]Ticket, error) {
 	for dataPerPage.NextPage != prevPage {
 		result = append(result, dataPerPage.Tickets...)
 		prevPage = dataPerPage.NextPage
+		fmt.Println(prevPage)
+		if prevPage == "" {
+			break;
+		}
 		res, _ := c.request("GET", dataPerPage.NextPage[38:], headers, bytes.NewReader(payload))
+		dataPerPage = new(APIPayload)
 		err = unmarshall(res, dataPerPage)
 	}
 


### PR DESCRIPTION
the existing **geAll** function return the wrong info because every time the page is extracted, it overwrites the old one. To fix that, assign **dataPerPage** to a new address in each iteration.