### PR TITLE
[REVIEW] pull zendesk ticket one by one

### DIFF
--- a/zendesk/zd_ticket_service.go
+++ b/zendesk/zd_ticket_service.go
@@ -14,13 +14,13 @@ import (
 //
 // Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/tickets
 type Ticket struct {
-	ID          int64  `json:"id,omitempty"`
-	URL         string `json:"url,omitempty"`
-	ExternalID  string `json:"external_id,omitempty"`
-	Type        string `json:"type,omitempty"`
-	Subject     string `json:"subject,omitempty"`
-	RawSubject  string `json:"raw_subject,omitempty"`
-	Description string `json:"description,omitempty"`
+	ID                 int64         `json:"id,omitempty"`
+	URL                string        `json:"url,omitempty"`
+	ExternalID         string        `json:"external_id,omitempty"`
+	Type               string        `json:"type,omitempty"`
+	Subject            string        `json:"subject,omitempty"`
+	RawSubject         string        `json:"raw_subject,omitempty"`
+	Description        string        `json:"description,omitempty"`
 	Priority           string        `json:"priority,omitempty"`
 	Status             string        `json:"status,omitempty"`
 	Recipient          string        `json:"recipient,omitempty"`
@@ -78,7 +78,7 @@ func (c *client) GetAllTickets() ([]Ticket, error) {
 */
 
 func (c *client) GetAllTickets() ([]Ticket, error) {
-	tickets, err := c.getAll("/api/v2/tickets.json", nil)
+	tickets, err := c.getOneByOne(nil)
 	return tickets, err
 }
 
@@ -135,7 +135,6 @@ func (c *client) ListTicketIncidents(problemID int64) ([]Ticket, error) {
 func (c *client) DeleteTicket(id int64) error {
 	return c.delete(fmt.Sprintf("/api/v2/tickets/%d.json", id), nil)
 }
-
 
 func (c *client) ListTicketComments(id int64) ([]TicketComment, error) {
 	out := new(APIPayload)

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -307,7 +307,7 @@ func (c *client) getOneByOne(in interface{}) ([]Ticket, error) {
 
 		// handle page not found
 		if res.StatusCode == 404 {
-			log.Printf("404 not found: %s\n", endpoint)
+			log.Printf("[ZENDESK] 404 not found: %s\n", endpoint)
 			// handle too many requests (rate limit)
 		} else if res.StatusCode == 429 {
 			after, err := strconv.ParseInt(res.Header.Get("Retry-After"), 10, 64)

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -288,7 +288,7 @@ func (c *client) getOneByOne(in interface{}) ([]Ticket, error) {
 	if in != nil {
 		headers["Content-Type"] = "application/json"
 	}
-	dataPerPage := new(APIPayload)
+	record := new(APIPayload)
 
 	// currently we can manually set the starting and ending IDs for data pulling
 	// because memory may reach its limit if the dataset is too large
@@ -319,15 +319,15 @@ func (c *client) getOneByOne(in interface{}) ([]Ticket, error) {
 			time.Sleep(time.Duration(after) * time.Second)
 			continue
 		} else {
-			err = unmarshall(res, dataPerPage)
+			err = unmarshall(res, record)
 			if err != nil {
 				return nil, err
 			}
 
-			result = append(result, *dataPerPage.Ticket)
+			result = append(result, *record.Ticket)
 		}
 
-		dataPerPage = new(APIPayload)
+		record = new(APIPayload)
 		ticketID++
 		endpoint = fmt.Sprintf("%s%v%s", endpointPrefix, ticketID, endpointPostfix)
 		res, _ = c.request("GET", endpoint, headers, bytes.NewReader(payload))

--- a/zendesk/zendesk_client_service.go
+++ b/zendesk/zendesk_client_service.go
@@ -275,6 +275,71 @@ func (c *client) getAll(endpoint string, in interface{}) ([]Ticket, error) {
 	return result, err
 }
 
+func (c *client) getOneByOne(in interface{}) ([]Ticket, error) {
+	endpointPrefix := "/api/v2/tickets/"
+	endpointPostfix := ".json"
+	result := make([]Ticket, 0)
+	payload, err := marshall(in)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := map[string]string{}
+	if in != nil {
+		headers["Content-Type"] = "application/json"
+	}
+	dataPerPage := new(APIPayload)
+
+	// currently we can manually set the starting and ending IDs for data pulling
+	// because memory may reach its limit if the dataset is too large
+	// ideally, we want to load data to database in batches on the fly
+	// instead of loading the entire chunk
+	startID := 1
+	endID := 10000
+	ticketID := startID // start
+	endpoint := fmt.Sprintf("%s%v%s", endpointPrefix, ticketID, endpointPostfix)
+	res, err := c.request("GET", endpoint, headers, bytes.NewReader(payload))
+	defer res.Body.Close()
+
+	var totalWaitTime int64
+	for ticketID < endID {
+		log.Printf("[ZENDESK] currently extracting: %s\n", endpoint)
+
+		// handle page not found
+		if res.StatusCode == 404 {
+			log.Printf("404 not found: %s\n", endpoint)
+			continue
+		}
+
+		// handle too many requests (rate limit)
+		if res.StatusCode == 429 {
+			after, err := strconv.ParseInt(res.Header.Get("Retry-After"), 10, 64)
+			log.Printf("[ZENDESK] too many requests. Wait for %v seconds\n", after)
+			totalWaitTime += after
+			if err != nil {
+				return nil, err
+			}
+			time.Sleep(time.Duration(after) * time.Second)
+			continue
+		}
+
+		err = unmarshall(res, dataPerPage)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, *dataPerPage.Ticket)
+		dataPerPage = new(APIPayload)
+		ticketID++
+		endpoint = fmt.Sprintf("%s%v%s", endpointPrefix, ticketID, endpointPostfix)
+		res, _ = c.request("GET", endpoint, headers, bytes.NewReader(payload))
+	}
+
+	log.Printf("[ZENDESK] number of records pulled: %v\n", len(result))
+	log.Printf("[ZENDESK] total waiting time due to rate limit: %v\n", totalWaitTime)
+	return result, nil
+}
+
 func (c *client) post(endpoint string, in, out interface{}) error {
 	return c.do("POST", endpoint, in, out)
 }


### PR DESCRIPTION
**Background**: we used **getAll** to pull Zendesk tickets in bulk but a lot of ticket ids are missing
so we decided to extract each ticket individually

**Solution**: **getOneByOne** is to pull the tickets individually. It handles 404(not found) and 429(too many requests) errors. Due to the large amount of data, we need to manually specify a **startID** and **endID** to avoid reach the memory limit.

**Drawback**: currently we can only load one big chunk of data into database. This method is limited by memory size. So we need to manually specify a range and run the program multiple times in order to get all the tickets.

**Future improve**: we should load the tickets to database on the fly. As soon as we receive a number of tickets, say 1000, we load it to database and clear the memory to capture the incoming tickets. In this approach, we can run the program only once to get all the tickets.